### PR TITLE
feat: allow ungrouped quote requests on dashboard

### DIFF
--- a/src/app/dashboard/ProjectsManager.tsx
+++ b/src/app/dashboard/ProjectsManager.tsx
@@ -3,13 +3,17 @@
 import { useState } from 'react';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import QuoteRequestActions from '@/components/quote-requests/QuoteRequestActions';
+import CreateQuoteRequest from '@/components/quote-requests/CreateQuoteRequest';
+import ImageLightbox from '@/components/ui/ImageLightbox';
 
 // Types for projects and session
-type Project = { id: string; nom_groupe: string; entreprises: { nom_entreprise: string } | null };
+type QuoteRequest = { id: string; nom_produit: string; quantite: number; photo_url: string | null };
+type Project = { id: string; nom_groupe: string; quote_requests: QuoteRequest[] };
 type Session = { user: { id: string } };
 
 interface ProjectsManagerProps {
@@ -61,15 +65,49 @@ export default function ProjectsManager({ projects, session }: ProjectsManagerPr
         <div className="mt-4">
           <h3 className="font-semibold">Vos projets :</h3>
           {projects.length > 0 ? (
-            <ul className="list-disc pl-5 mt-2 space-y-1">
+            <div className="space-y-4 mt-2">
               {projects.map((project) => (
-                <li key={project.id}>
-                  <Link href={`/dashboard/groupe/${project.id}`} className="text-blue-600 hover:underline">
-                    {project.nom_groupe} ({project.entreprises?.nom_entreprise || 'Sans entreprise'})
-                  </Link>
-                </li>
+                <details key={project.id} className="border rounded">
+                  <summary className="cursor-pointer select-none p-2 font-medium">
+                    {project.nom_groupe}
+                  </summary>
+                  <div className="p-2">
+                    <div className="flex justify-end mb-2">
+                      <CreateQuoteRequest groupId={project.id} />
+                    </div>
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Photo</TableHead>
+                          <TableHead>Produit</TableHead>
+                          <TableHead>Qté</TableHead>
+                          <TableHead className="text-right">Actions</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {project.quote_requests && project.quote_requests.map((request) => (
+                          <TableRow key={request.id}>
+                            <TableCell>
+                              {request.photo_url && (
+                                <ImageLightbox src={request.photo_url} alt={request.nom_produit} />
+                              )}
+                            </TableCell>
+                            <TableCell className="font-medium">{request.nom_produit}</TableCell>
+                            <TableCell>{request.quantite}</TableCell>
+                            <TableCell className="text-right">
+                              <QuoteRequestActions request={request} />
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                    {(project.quote_requests?.length ?? 0) === 0 && (
+                      <p className="text-sm text-gray-500 py-4 text-center">Aucune demande.</p>
+                    )}
+                  </div>
+                </details>
               ))}
-            </ul>
+            </div>
           ) : (
             <p className="text-sm text-gray-500 mt-2">Vous n'avez pas encore créé de projet.</p>
           )}

--- a/src/app/dashboard/groupe/[id]/page.tsx
+++ b/src/app/dashboard/groupe/[id]/page.tsx
@@ -9,9 +9,9 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import CreateQuoteRequest from './CreateQuoteRequest';
+import CreateQuoteRequest from '@/components/quote-requests/CreateQuoteRequest';
 import QuoteSummary from './QuoteSummary';
-import QuoteRequestActions from './QuoteRequestActions';
+import QuoteRequestActions from '@/components/quote-requests/QuoteRequestActions';
 import ImageLightbox from '@/components/ui/ImageLightbox'; // Using the alias for a cleaner import
 
 export default async function GroupePage({ params: { id: groupId } }: { params: { id: string } }) {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,30 +1,80 @@
 import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
 import ProjectsManager from './ProjectsManager';
+import CreateQuoteRequest from '@/components/quote-requests/CreateQuoteRequest';
+import QuoteRequestActions from '@/components/quote-requests/QuoteRequestActions';
+import ImageLightbox from '@/components/ui/ImageLightbox';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 
 export default async function Dashboard() {
   const supabase = createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect('/login');
 
-  const { data: projects } = await supabase
+  const { data: groups } = await supabase
     .from('quote_groups')
-    .select('id, nom_groupe, entreprises!inner ( nom_entreprise )') // Utilise ! pour forcer la jointure
+    .select('id, nom_groupe, quote_requests ( id, nom_produit, quantite, photo_url )')
     .eq('id_client_session', user.id)
     .order('created_at', { ascending: false });
 
-  const normalizedProjects = (projects || []).map((p) => ({
-    ...p,
-    entreprises: p.entreprises?.[0] || { nom_entreprise: 'Inconnu' } // on extrait le premier élément
-  }));
+  const { data: ungroupedRequests } = await supabase
+    .from('quote_requests')
+    .select('*')
+    .is('id_groupe_devis', null)
+    .order('created_at', { ascending: false });
 
   const session = { user };
 
   return (
     <div>
       <h1 className="text-3xl font-bold mb-4">Dashboard</h1>
+
+      <section className="mb-8">
+        <header className="flex justify-between items-center mb-4">
+          <h2 className="text-2xl font-semibold">Requêtes seules</h2>
+          <CreateQuoteRequest />
+        </header>
+        <Card>
+          <CardHeader>
+            <CardTitle>Demandes de Devis</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Photo</TableHead>
+                  <TableHead>Produit</TableHead>
+                  <TableHead>Qté</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {ungroupedRequests && ungroupedRequests.map((request) => (
+                  <TableRow key={request.id}>
+                    <TableCell>
+                      {request.photo_url && (
+                        <ImageLightbox src={request.photo_url} alt={request.nom_produit} />
+                      )}
+                    </TableCell>
+                    <TableCell className="font-medium">{request.nom_produit}</TableCell>
+                    <TableCell>{request.quantite}</TableCell>
+                    <TableCell className="text-right">
+                      <QuoteRequestActions request={request} />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            {(!ungroupedRequests || ungroupedRequests.length === 0) && (
+              <p className="text-center text-gray-500 py-4">Aucune demande libre.</p>
+            )}
+          </CardContent>
+        </Card>
+      </section>
+
       <ProjectsManager
-        projects={normalizedProjects}
+        projects={groups || []}
         session={session}
       />
     </div>

--- a/src/app/dashboard/projects/page.tsx
+++ b/src/app/dashboard/projects/page.tsx
@@ -7,16 +7,11 @@ export default async function ProjectsPage() {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect('/login');
 
-  const { data: projects } = await supabase
+  const { data: groups } = await supabase
     .from('quote_groups')
-    .select('id, nom_groupe, entreprises!inner ( nom_entreprise )')
+    .select('id, nom_groupe, quote_requests ( id, nom_produit, quantite, photo_url )')
     .eq('id_client_session', user.id)
     .order('created_at', { ascending: false });
-
-  const normalizedProjects = (projects || []).map((p) => ({
-    ...p,
-    entreprises: p.entreprises?.[0] || { nom_entreprise: 'Inconnu' }
-  }));
 
   const session = { user };
 
@@ -24,7 +19,7 @@ export default async function ProjectsPage() {
     <div>
       <h1 className="text-3xl font-bold mb-4">Projets</h1>
       <ProjectsManager
-        projects={normalizedProjects}
+        projects={groups || []}
         session={session}
       />
     </div>

--- a/src/components/quote-requests/CreateQuoteRequest.tsx
+++ b/src/components/quote-requests/CreateQuoteRequest.tsx
@@ -9,7 +9,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea'; // Assurez-vous que c'est importé
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 
-export default function CreateQuoteRequest({ groupId }: { groupId: string }) {
+export default function CreateQuoteRequest({ groupId }: { groupId?: string | null }) {
   const [open, setOpen] = useState(false);
   const [productName, setProductName] = useState('');
   const [quantity, setQuantity] = useState('');
@@ -40,7 +40,7 @@ export default function CreateQuoteRequest({ groupId }: { groupId: string }) {
     const { data: { publicUrl } } = supabase.storage.from('images').getPublicUrl(fileName);
 
     const { error: insertError } = await supabase.from('quote_requests').insert({
-      id_groupe_devis: groupId,
+      id_groupe_devis: groupId || null,
       nom_produit: productName,
       quantite: parseInt(quantity, 10),
       photo_url: publicUrl,

--- a/src/components/quote-requests/EditQuoteRequest.tsx
+++ b/src/components/quote-requests/EditQuoteRequest.tsx
@@ -16,7 +16,7 @@ type QuoteRequest = {
   nom_produit: string;
   quantite: number;
   details?: string;
-  photo_url: string;
+  photo_url: string | null;
 };
 
 export default function EditQuoteRequest({ request }: { request: QuoteRequest }) {
@@ -30,7 +30,7 @@ export default function EditQuoteRequest({ request }: { request: QuoteRequest })
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    let updatedPhotoUrl = request.photo_url;
+    let updatedPhotoUrl = request.photo_url || '';
 
     if (newFile) {
       const fileExt = newFile.name.split('.').pop();
@@ -73,9 +73,11 @@ export default function EditQuoteRequest({ request }: { request: QuoteRequest })
             <Label htmlFor="details">Détails (Optionnel)</Label>
             <Textarea id="details" value={details} onChange={(e) => setDetails(e.target.value)} />
 
-            <Label htmlFor="photo">Changer la photo</Label>
-            <Image src={request.photo_url} alt="Photo actuelle" width={80} height={80} className="rounded-md object-cover my-2" />
-            <Input id="photo" type="file" onChange={(e) => setNewFile(e.target.files ? e.target.files[0] : null)} />
+              <Label htmlFor="photo">Changer la photo</Label>
+              {request.photo_url && (
+                <Image src={request.photo_url} alt="Photo actuelle" width={80} height={80} className="rounded-md object-cover my-2" />
+              )}
+              <Input id="photo" type="file" onChange={(e) => setNewFile(e.target.files ? e.target.files[0] : null)} />
           </div>
           <DialogFooter>
             <Button type="submit">Enregistrer</Button>

--- a/src/components/quote-requests/QuoteRequestActions.tsx
+++ b/src/components/quote-requests/QuoteRequestActions.tsx
@@ -13,7 +13,7 @@ type QuoteRequest = {
   nom_produit: string;
   quantite: number;
   details?: string;
-  photo_url: string;
+  photo_url: string | null;
 };
 
 export default function QuoteRequestActions({ request }: { request: QuoteRequest }) {


### PR DESCRIPTION
## Summary
- allow creating quote requests without a group
- list ungrouped requests directly on the dashboard
- reuse quote request actions for both grouped and ungrouped entries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*
- `npm run build` *(fails: either NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables or supabaseUrl and supabaseKey are required)*

------
https://chatgpt.com/codex/tasks/task_e_688c39cd6e088333878c87622fdf9cfc